### PR TITLE
Bump up to Idea 2023.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/bizyback/ding
 pluginVersion = 0.0.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 223
+pluginSinceBuild = 232
 pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2022.3.3
+platformVersion = 2023.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/bizyback/ding/listeners/DingIndexingListener.kt
+++ b/src/main/kotlin/com/bizyback/ding/listeners/DingIndexingListener.kt
@@ -3,8 +3,8 @@ package com.bizyback.ding.listeners
 import com.bizyback.ding.settings.DingSettings
 import com.bizyback.ding.utils.ring
 import com.intellij.openapi.components.service
-import com.intellij.util.indexing.diagnostic.ProjectIndexingHistory
-import com.intellij.util.indexing.diagnostic.ProjectIndexingHistoryListener
+import com.intellij.util.indexing.diagnostic.ProjectDumbIndexingHistory
+import com.intellij.util.indexing.diagnostic.ProjectIndexingActivityHistoryListener
 
 /**
  *
@@ -15,11 +15,11 @@ import com.intellij.util.indexing.diagnostic.ProjectIndexingHistoryListener
  * @time     12:29 am
  *
  */
-class DingIndexingListener : ProjectIndexingHistoryListener {
+class DingIndexingListener : ProjectIndexingActivityHistoryListener {
 
     private val settings = service<DingSettings>()
 
-    override fun onFinishedIndexing(projectIndexingHistory: ProjectIndexingHistory) {
+    override fun onFinishedDumbIndexing(history: ProjectDumbIndexingHistory) {
         if (settings.indexingEnabled) ring(settings.indexingTone)
     }
 


### PR DESCRIPTION
This PR presents one of the options to solve for use of deprecated `ProjectExecutionHistoryListener` to the use of newer `ProjectExecutionActivityHistoryListener`. This will bump the minimum requirements of integrating the plugin from IntelliJ Idea 2022.3 (Android Studio Giraffe) to 2023.2 (Android Studio Iguana).